### PR TITLE
Potential fix for code scanning alert no. 40: Unsafe jQuery plugin

### DIFF
--- a/src/E-Commerce-BE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/E-Commerce-BE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -766,6 +766,12 @@ $.extend( $.validator, {
 		check: function( element ) {
 			element = this.validationTargetFor( this.clean( element ) );
 
+			// Ensure element is a DOM node and not a string to avoid XSS through selectors
+			if (typeof element === "string") {
+				// If element is a string, reject it safely
+				return false;
+			}
+
 			var rules = $( element ).rules(),
 				rulesCount = $.map( rules, function( n, i ) {
 					return i;


### PR DESCRIPTION
Potential fix for [https://github.com/dihaxn/E-Commerce-Web-App/security/code-scanning/40](https://github.com/dihaxn/E-Commerce-Web-App/security/code-scanning/40)

The best way to fix this vulnerability is to ensure that the `element` passed to functions like `$(element)` (especially in the `.rules()` call on line 769) is always a DOM element and never a string. This can be safely achieved by adding a type check before passing `element` to jQuery: if `element` is not a DOM node, the code should ignore it or throw an error. The `check` function (and any related API entry points) should be patched to verify that `element` is not a string, and if it is, either reject it or convert it to a DOM reference using safe selectors. Additionally, documentation should clarify the expected type of the options—however, in this case, the security fix is to programmatically ensure the value is not dangerous.

Technically, insert a type check at the beginning of `check`, so that if the `element` is a string, we do not attempt to use it with jQuery as if it were a selector (especially since strings starting with `<` will be parsed as HTML). Alternatively, wrap `element` with `$(...)` and verify its length is nonzero and that the 0th value is a DOM node.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
