### PR TITLE
Fix noisy Monitoring & Alerting workflow failures

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -2,7 +2,7 @@ name: 📊 Monitoring & Alerting
 
 on:
   schedule:
-    - cron: "*/5 * * * *" # Every 5 minutes
+    - cron: "*/30 * * * *" # Every 30 minutes (reduce noisy notifications)
   workflow_dispatch:
 
 jobs:
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Alert on health check failure
-        if: steps.health-prod.outputs.status == 'unhealthy' || steps.db-health.outputs.status == 'unhealthy'
+        if: (steps.health-prod.outputs.status == 'unhealthy' || steps.db-health.outputs.status == 'unhealthy') && secrets.SLACK_WEBHOOK_URL != ''
         uses: 8398a7/action-slack@v3
         with:
           status: failure
@@ -77,7 +77,7 @@ jobs:
       - name: Install curl and jq
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl jq
+          sudo apt-get install -y curl jq bc
 
       - name: Measure response times
         id: response-times
@@ -118,7 +118,7 @@ jobs:
           fi
 
       - name: Alert on slow performance
-        if: steps.performance-check.outputs.status == 'slow'
+        if: steps.performance-check.outputs.status == 'slow' && secrets.SLACK_WEBHOOK_URL != ''
         uses: 8398a7/action-slack@v3
         with:
           status: warning
@@ -193,7 +193,7 @@ jobs:
           fi
 
       - name: Alert on security issues
-        if: steps.security-headers.outputs.frame_options == 'missing' || steps.security-headers.outputs.content_type_options == 'missing' || steps.security-headers.outputs.xss_protection == 'missing' || steps.security-headers.outputs.hsts == 'missing' || steps.https-check.outputs.http_redirect == 'not_working' || steps.https-check.outputs.https_working == 'no'
+        if: (steps.security-headers.outputs.frame_options == 'missing' || steps.security-headers.outputs.content_type_options == 'missing' || steps.security-headers.outputs.xss_protection == 'missing' || steps.security-headers.outputs.hsts == 'missing' || steps.https-check.outputs.http_redirect == 'not_working' || steps.https-check.outputs.https_working == 'no') && secrets.SLACK_WEBHOOK_URL != ''
         uses: 8398a7/action-slack@v3
         with:
           status: failure
@@ -247,7 +247,7 @@ jobs:
           fi
 
       - name: Alert on downtime
-        if: steps.uptime-check.outputs.status == 'down'
+        if: steps.uptime-check.outputs.status == 'down' && secrets.SLACK_WEBHOOK_URL != ''
         uses: 8398a7/action-slack@v3
         with:
           status: failure


### PR DESCRIPTION
### Motivation

- The monitoring workflow was triggering frequent failure emails and alerts due to a high cron frequency and some missing dependencies and secrets checks. 
- The change aims to reduce noise and prevent workflow failures without adding any paid features.

### Description

- Reduced the scheduled run from every 5 minutes to every 30 minutes by changing the cron from `*/5 * * * *` to `*/30 * * * *` in `.github/workflows/monitoring.yml`.
- Installed `bc` in the performance job (`sudo apt-get install -y curl jq bc`) to support numeric threshold calculations used by the job.
- Guarded all Slack alert steps so they only run when the `SLACK_WEBHOOK_URL` secret is set by adding `&& secrets.SLACK_WEBHOOK_URL != ''` to the alert `if` conditions for health, performance, security, and uptime checks.
- Kept message text and behavior unchanged otherwise, and grouped conditionals for clarity to avoid unintended alerts or failures.

### Testing

- The workflow file was patched with a short Python script to update the YAML and the change was verified with `git diff -- .github/workflows/monitoring.yml`, which showed the intended edits and succeeded. 
- The updated file was staged and committed using `git add -f .github/workflows/monitoring.yml` and `git commit -m "Fix noisy monitoring workflow failures and alerts"`, and the commit succeeded. 
- No CI run was executed as part of this change in the sandbox, so runtime behavior should be validated by observing the next scheduled run or triggering the workflow manually with `workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec354c9a48832084ae414db98133c2)